### PR TITLE
app-layout: Improve a11y of sidebar

### DIFF
--- a/.changeset/thick-items-jam.md
+++ b/.changeset/thick-items-jam.md
@@ -1,0 +1,5 @@
+---
+'@ag.common/app-layout': patch
+---
+
+app-layout: Improve screen reader experience of "messages" menu item when there is an unread message. Instead of announcing "Messages 6", it will now announce "Messages, 6 unread".

--- a/packages/app-layout/src/__snapshots__/AppLayout.test.tsx.snap
+++ b/packages/app-layout/src/__snapshots__/AppLayout.test.tsx.snap
@@ -308,17 +308,20 @@ exports[`AppLayout renders correctly 1`] = `
               <span>
                 Messages
               </span>
-              <span
-                class="css-p2x7aq-boxStyles-boxStyles-Text-NotificationBadge"
-              >
-                6
-              </span>
-              <span
-                class="css-avudkd-VisuallyHidden"
-              >
-                , 
-                6
-                 unread
+              <span>
+                <span
+                  aria-hidden="true"
+                  class="css-p2x7aq-boxStyles-boxStyles-Text-NotificationBadge"
+                >
+                  6
+                </span>
+                <span
+                  class="css-avudkd-VisuallyHidden"
+                >
+                  , 
+                  6
+                   unread
+                </span>
               </span>
             </a>
           </li>

--- a/packages/app-layout/src/__snapshots__/AppLayout.test.tsx.snap
+++ b/packages/app-layout/src/__snapshots__/AppLayout.test.tsx.snap
@@ -313,6 +313,13 @@ exports[`AppLayout renders correctly 1`] = `
               >
                 6
               </span>
+              <span
+                class="css-avudkd-VisuallyHidden"
+              >
+                , 
+                6
+                 unread
+              </span>
             </a>
           </li>
           <li

--- a/packages/app-layout/src/utils.tsx
+++ b/packages/app-layout/src/utils.tsx
@@ -9,6 +9,8 @@ import {
 	SettingsIcon,
 	FactoryIcon,
 } from '@ag.ds-next/react/icon';
+import { VisuallyHidden } from '@ag.ds-next/react/a11y';
+import { Fragment } from 'react';
 
 export const footerNavigationItems = [
 	{
@@ -70,11 +72,14 @@ export function getSidebarLinks({
 				href: '/account/messages',
 				endElement:
 					typeof unreadMessageCount === 'number' && unreadMessageCount > 0 ? (
-						<NotificationBadge
-							tone="action"
-							value={unreadMessageCount}
-							max={99}
-						/>
+						<Fragment>
+							<NotificationBadge
+								tone="action"
+								value={unreadMessageCount}
+								max={99}
+							/>
+							<VisuallyHidden>, {unreadMessageCount} unread</VisuallyHidden>
+						</Fragment>
 					) : undefined,
 			},
 			{
@@ -88,7 +93,6 @@ export function getSidebarLinks({
 				href: '/help',
 			},
 		],
-
 		[
 			{
 				label: 'Sign out',

--- a/packages/app-layout/src/utils.tsx
+++ b/packages/app-layout/src/utils.tsx
@@ -10,7 +10,6 @@ import {
 	FactoryIcon,
 } from '@ag.ds-next/react/icon';
 import { VisuallyHidden } from '@ag.ds-next/react/a11y';
-import { Fragment } from 'react';
 
 export const footerNavigationItems = [
 	{
@@ -72,14 +71,15 @@ export function getSidebarLinks({
 				href: '/account/messages',
 				endElement:
 					typeof unreadMessageCount === 'number' && unreadMessageCount > 0 ? (
-						<Fragment>
+						<span>
 							<NotificationBadge
 								tone="action"
 								value={unreadMessageCount}
 								max={99}
+								aria-hidden
 							/>
 							<VisuallyHidden>, {unreadMessageCount} unread</VisuallyHidden>
-						</Fragment>
+						</span>
 					) : undefined,
 			},
 			{


### PR DESCRIPTION
## Describe your changes

Improve screen reader experience of "messages" menu item when there is an unread message. Instead of announcing "Messages 6", it will now announce "Messages, 6 unread".

## Checklist

- [x] Read and check your code before tagging someone for review.
- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [x] Add necessary tests
- [x] Run `yarn changeset` to create a changeset file
- [ ] Write documentation (README.md)
- [ ] Create stories for Storybook