### PR TITLE
app-layout: Make `userName` optional

### DIFF
--- a/.changeset/little-teachers-reflect.md
+++ b/.changeset/little-teachers-reflect.md
@@ -1,0 +1,5 @@
+---
+'@ag.common/app-layout': patch
+---
+
+Made `userName` prop optional to allow client-side fetching of user name. If no `userName` is supplied, the account details in the top right of the header will not be rendered.

--- a/packages/app-layout/src/AppLayout.stories.tsx
+++ b/packages/app-layout/src/AppLayout.stories.tsx
@@ -1,4 +1,4 @@
-import { Fragment } from 'react';
+import { Fragment, useEffect, useState } from 'react';
 import { StoryObj, Meta } from '@storybook/react';
 import { Prose } from '@ag.ds-next/react/prose';
 import { PageContent } from '@ag.ds-next/react/content';
@@ -50,5 +50,46 @@ export const FocusMode: Story = {
 		userOrganisation: 'Orange Meat Works',
 		unreadMessageCount: 6,
 		activePath: '/',
+	},
+};
+
+export const ClientSideFetch: Story = {
+	args: {
+		activePath: '/',
+		focusMode: false,
+	},
+	render: function Render(props) {
+		const [userDetails, setUserDetails] = useState(false);
+
+		// Mock fetching the user
+		useEffect(() => {
+			setTimeout(() => {
+				setUserDetails(true);
+			}, 1000);
+		}, []);
+
+		return (
+			<Fragment>
+				<SkipLinks
+					links={[{ href: '#main-content', label: 'Skip to main content' }]}
+				/>
+				<AppLayout
+					{...props}
+					{...(userDetails
+						? {
+								userName: 'Toto Wolff',
+								userOrganisation: 'Orange Meat Works',
+								unreadMessageCount: 6,
+						  }
+						: {})}
+				>
+					<PageContent>
+						<Prose>
+							<h1>Page heading</h1>
+						</Prose>
+					</PageContent>
+				</AppLayout>
+			</Fragment>
+		);
 	},
 };

--- a/packages/app-layout/src/AppLayout.tsx
+++ b/packages/app-layout/src/AppLayout.tsx
@@ -19,7 +19,7 @@ export type AppLayoutProps = PropsWithChildren<{
 	handleSignOut: () => Promise<void>;
 	mainContentId?: string;
 	unreadMessageCount?: number;
-	userName: string;
+	userName?: string;
 	userOrganisation?: string;
 }>;
 
@@ -58,11 +58,15 @@ export function AppLayout({
 					subLine="Supporting Australian agricultural exports"
 					badgeLabel="Beta"
 					logo={<Logo />}
-					accountDetails={{
-						href: '/account/settings',
-						name: userName,
-						secondaryText: userOrganisation,
-					}}
+					accountDetails={
+						userName
+							? {
+									href: '/account/settings',
+									name: userName,
+									secondaryText: userOrganisation,
+							  }
+							: undefined
+					}
 				/>
 				<AgDsAppLayoutSidebar activePath={activePath} items={sidebarLinks} />
 


### PR DESCRIPTION
## Describe your changes

Made `userName` prop optional to allow client-side fetching of user name. If no `userName` is supplied, the account details in the top right of the header will not be rendered.

[View preview](https://steelthreads.github.io/ag-common/pr-preview/pr-70/?path=/story/applayout--client-side-fetch)

## Checklist

- [x] Read and check your code before tagging someone for review.
- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [x] Add necessary tests
- [x] Run `yarn changeset` to create a changeset file
- [ ] Write documentation (README.md)
- [x] Create stories for Storybook