### PR TITLE
app-layout: highlight dashboard when on account link

### DIFF
--- a/.changeset/yellow-houses-repair.md
+++ b/.changeset/yellow-houses-repair.md
@@ -1,0 +1,5 @@
+---
+'@ag.common/app-layout': patch
+---
+
+Transformed active path to ensure that the "Dashboard" link when we are on an `/account` subpath

--- a/packages/app-layout/src/AppLayout.tsx
+++ b/packages/app-layout/src/AppLayout.tsx
@@ -62,10 +62,9 @@ export function AppLayout<B extends Business>({
 	// Select the "Dashboard" link when we are on an account subpath
 	const activePath = useMemo(() => {
 		if (
-			activePathProp !== hrefs.account &&
-			activePathProp.startsWith(hrefs.account)
+			activePathProp.startsWith(hrefs.account) &&
+			activePathProp !== hrefs.account
 		) {
-			// Select the "dashboard instead"
 			return hrefs.dashboard;
 		}
 		activePathProp;

--- a/packages/app-layout/src/AppLayout.tsx
+++ b/packages/app-layout/src/AppLayout.tsx
@@ -30,7 +30,7 @@ export type AppLayoutProps<B extends Business> = PropsWithChildren<{
 }>;
 
 export function AppLayout<B extends Business>({
-	activePath,
+	activePath: activePathProp,
 	children,
 	focusMode = false,
 	handleSignOut,
@@ -58,6 +58,18 @@ export function AppLayout<B extends Business>({
 		],
 		[onSignOutClick, businessDetails]
 	);
+
+	// Select the "Dashboard" link when we are on an account subpath
+	const activePath = useMemo(() => {
+		if (
+			activePathProp !== hrefs.account &&
+			activePathProp.startsWith(hrefs.account)
+		) {
+			// Select the "dashboard instead"
+			return hrefs.dashboard;
+		}
+		activePathProp;
+	}, [activePathProp]);
 
 	return (
 		<AgDsAppLayout focusMode={focusMode}>

--- a/packages/app-layout/src/AppLayoutDropdown.tsx
+++ b/packages/app-layout/src/AppLayoutDropdown.tsx
@@ -81,7 +81,10 @@ const LinkedBusinesses = (props: {
 				</DropdownMenuItemRadio>
 			))}
 			{props.businesses.length > 3 ? (
-				<DropdownMenuItemLink href="/account" endElement={<ArrowRightIcon />}>
+				<DropdownMenuItemLink
+					href={hrefs.account}
+					endElement={<ArrowRightIcon />}
+				>
 					View all businesses
 				</DropdownMenuItemLink>
 			) : null}
@@ -145,7 +148,7 @@ export const getBusinessSidebarLinks = <T extends Business>(
 						{
 							label: 'Back to my account',
 							icon: ChevronsLeftIcon,
-							href: '/account',
+							href: hrefs.account,
 						},
 					],
 				},

--- a/packages/app-layout/src/utils.tsx
+++ b/packages/app-layout/src/utils.tsx
@@ -11,6 +11,7 @@ import { Flex } from '@ag.ds-next/react/flex';
 import { ExternalLinkCallout } from '@ag.ds-next/react/a11y';
 
 export const hrefs = {
+	account: '/account',
 	profile: '/account/profile',
 	dashboard: '/account/dashboard',
 	messages: '/account/messages',


### PR DESCRIPTION
## Describe your changes

Transformed active path to ensure that the "Dashboard" link when we are on an `/account` subpath

<img width="2040" alt="Screenshot 2023-10-06 at 10 42 07 am" src="https://github.com/steelthreads/ag-common/assets/6265154/46e5544e-a5ee-49b9-90aa-243968e3d29a">

## Checklist

- [x] Read and check your code before tagging someone for review.
- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [x] Add necessary tests
- [x] Run `yarn changeset` to create a changeset file
- [ ] Write documentation (README.md)
- [ ] Create stories for Storybook