### PR TITLE
Support app router with use client. Update deps

### DIFF
--- a/.changeset/clean-owls-try.md
+++ b/.changeset/clean-owls-try.md
@@ -15,9 +15,9 @@ app-layout: Add `'use client'` to all exports. Use AgDS’ `PieChartIcon` instea
 
 digital-identity: Add `'use client'` to all exports. Update internal layout components to not use deprecated versions.
 
-footer: Remove incorrect use of `CoreProvider`.
+footer: Add `'use client'` to all exports.
 
-header: Remove incorrect use of `CoreProvider`. Remove deprecated `MainNavBottomBar`.
+header: Add `'use client'` to all exports. Remove deprecated `MainNavBottomBar`.
 
-help-callout: Remove incorrect use of `CoreProvider`.
+help-callout: Add `'use client'` to all exports.
 

--- a/.changeset/clean-owls-try.md
+++ b/.changeset/clean-owls-try.md
@@ -1,0 +1,23 @@
+---
+'@ag.common/digital-identity': minor
+'@ag.common/help-callout': minor
+'@ag.common/app-layout': minor
+'@ag.common/analytics': minor
+'@ag.common/footer': minor
+'@ag.common/header': minor
+---
+
+deps: Update @ag.ds-next/react to v1.29.0.
+
+analytics: Add `'use client'` to all exports.
+
+app-layout: Add `'use client'` to all exports. Use AgDS’ `PieChartIcon` instead of custom implementation.
+
+digital-identity: Add `'use client'` to all exports. Update internal layout components to not use deprecated versions.
+
+footer: Remove incorrect use of `CoreProvider`.
+
+header: Remove incorrect use of `CoreProvider`. Remove deprecated `MainNavBottomBar`.
+
+help-callout: Remove incorrect use of `CoreProvider`.
+

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
 		"storybook:build": "STORYBOOK=true storybook build -o docs/public/storybook"
 	},
 	"devDependencies": {
-		"@ag.ds-next/react": "^1.28.0",
+		"@ag.ds-next/react": "^1.29.0",
 		"@babel/core": "^7.24.0",
 		"@babel/plugin-transform-runtime": "^7.24.0",
 		"@babel/preset-env": "^7.24.0",

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -5,14 +5,14 @@
 	"module": "dist/ag.common-analytics.esm.js",
 	"license": "MIT",
 	"peerDependencies": {
-		"@ag.ds-next/react": "^1.28.0",
+		"@ag.ds-next/react": "^1.29.0",
 		"@emotion/react": "^11.7.0",
 		"@types/gtag.js": "^0.0.12",
 		"facepaint": "^1.2.1",
 		"react": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
 	},
 	"devDependencies": {
-		"@ag.ds-next/react": "^1.28.0",
+		"@ag.ds-next/react": "^1.29.0",
 		"@emotion/react": "^11.7.0",
 		"@types/gtag.js": "^0.0.12",
 		"facepaint": "^1.2.1",

--- a/packages/analytics/src/index.ts
+++ b/packages/analytics/src/index.ts
@@ -1,3 +1,4 @@
+'use client';
 export * from './Analytics';
 export * from './Scripts';
 export * from './Events';

--- a/packages/app-layout/package.json
+++ b/packages/app-layout/package.json
@@ -5,13 +5,13 @@
 	"module": "dist/ag.common-app-layout.esm.js",
 	"license": "MIT",
 	"peerDependencies": {
-		"@ag.ds-next/react": "^1.28.0",
+		"@ag.ds-next/react": "^1.29.0",
 		"@emotion/react": "^11.7.0",
 		"facepaint": "^1.2.1",
 		"react": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
 	},
 	"devDependencies": {
-		"@ag.ds-next/react": "^1.28.0",
+		"@ag.ds-next/react": "^1.29.0",
 		"@emotion/react": "^11.7.0",
 		"facepaint": "^1.2.1",
 		"react": "18.1.0 || 19.0.0"

--- a/packages/app-layout/src/__snapshots__/AppLayout.test.tsx.snap
+++ b/packages/app-layout/src/__snapshots__/AppLayout.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`AppLayout renders correctly 1`] = `
     class="css-3s22mq"
   >
     <header
-      class="css-wb1wis-dark-dark-boxStyles-boxStyles-AppLayoutHeader"
+      class="css-ro3xi5-dark-dark-boxStyles-boxStyles-AppLayoutHeader"
     >
       <div
         class="css-124u00k-boxStyles-boxStyles"

--- a/packages/app-layout/src/index.ts
+++ b/packages/app-layout/src/index.ts
@@ -1,3 +1,4 @@
+'use client';
 export * from './AppLayout';
 export { AppErrorComponents } from './AppLayoutContent';
 export { getReadableProof, hasSufficientProofing } from './proofing';

--- a/packages/app-layout/src/utils.tsx
+++ b/packages/app-layout/src/utils.tsx
@@ -1,18 +1,17 @@
 import {
 	ChartLineIcon,
 	ExitIcon,
+	ExternalLinkIcon,
+	FactoryIcon,
+	FileIcon,
 	HelpIcon,
 	HomeIcon,
-	FileIcon,
-	SuccessIcon,
-	FactoryIcon,
-	ExternalLinkIcon,
-	createIcon,
 	LicenceBusinessIcon,
+	PieChartIcon,
+	SuccessIcon,
 } from '@ag.ds-next/react/icon';
 import { Flex } from '@ag.ds-next/react/flex';
 import { ExternalLinkCallout } from '@ag.ds-next/react/a11y';
-import { Fragment } from 'react';
 
 export type Features = {
 	quotas?: boolean;
@@ -28,14 +27,6 @@ export const hrefs = {
 	linkBusiness: '/account/link-a-business',
 	acceptInvite: '/account/invitation/accept',
 };
-
-const PieChartIcon = createIcon(
-	<Fragment>
-		<path d="M21.21 15.89A10 10 0 1 1 8 2.83"></path>
-		<path d="M22 12A10 10 0 0 0 12 2v10z"></path>
-	</Fragment>,
-	'PieChartIcon'
-);
 
 export const footerNavigationItems = [
 	{

--- a/packages/digital-identity/package.json
+++ b/packages/digital-identity/package.json
@@ -5,13 +5,13 @@
 	"module": "dist/ag.common-digital-identity.esm.js",
 	"license": "MIT",
 	"peerDependencies": {
-		"@ag.ds-next/react": "^1.28.0",
+		"@ag.ds-next/react": "^1.29.0",
 		"@emotion/react": "^11.7.0",
 		"facepaint": "^1.2.1",
 		"react": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
 	},
 	"devDependencies": {
-		"@ag.ds-next/react": "^1.28.0",
+		"@ag.ds-next/react": "^1.29.0",
 		"@emotion/react": "^11.7.0",
 		"facepaint": "^1.2.1",
 		"react": "18.1.0 || 19.0.0"

--- a/packages/digital-identity/src/DigitalIdentity.tsx
+++ b/packages/digital-identity/src/DigitalIdentity.tsx
@@ -1,7 +1,9 @@
 import { MouseEventHandler } from 'react';
-import { Box, Flex, Stack } from '@ag.ds-next/react/box';
+import { Box } from '@ag.ds-next/react/box';
 import { BaseButton, buttonStyles } from '@ag.ds-next/react/button';
 import { packs, useLinkComponent } from '@ag.ds-next/react/core';
+import { Flex } from '@ag.ds-next/react/flex';
+import { Stack } from '@ag.ds-next/react/stack';
 import { Text } from '@ag.ds-next/react/text';
 import { TextLinkExternal } from '@ag.ds-next/react/text-link';
 import { DigitalIdentityLogo } from './Assets';

--- a/packages/digital-identity/src/__snapshots__/DigitalIdentity.test.tsx.snap
+++ b/packages/digital-identity/src/__snapshots__/DigitalIdentity.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`DigitalIdentity renders correctly 1`] = `
     class="css-fzcdfu-boxStyles-boxStyles"
   >
     <div
-      class="css-wiotlj-boxStyles-boxStyles-DigitalIdentity"
+      class="css-kmp9zn-boxStyles-boxStyles-DigitalIdentity"
     >
       <a
         class="css-1d0yep6"

--- a/packages/digital-identity/src/index.ts
+++ b/packages/digital-identity/src/index.ts
@@ -1,2 +1,3 @@
+'use client';
 export * from './DigitalIdentity';
 export * from './Assets';

--- a/packages/footer/package.json
+++ b/packages/footer/package.json
@@ -5,13 +5,13 @@
 	"module": "dist/ag.common-footer.esm.js",
 	"license": "MIT",
 	"peerDependencies": {
-		"@ag.ds-next/react": "^1.28.0",
+		"@ag.ds-next/react": "^1.29.0",
 		"@emotion/react": "^11.7.0",
 		"facepaint": "^1.2.1",
 		"react": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
 	},
 	"devDependencies": {
-		"@ag.ds-next/react": "^1.28.0",
+		"@ag.ds-next/react": "^1.29.0",
 		"@emotion/react": "^11.7.0",
 		"facepaint": "^1.2.1",
 		"react": "18.1.0 || 19.0.0"

--- a/packages/footer/src/Footer.tsx
+++ b/packages/footer/src/Footer.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import { Box } from '@ag.ds-next/react/box';
-import { tokens } from '@ag.ds-next/react/core';
+import { CoreProvider, tokens } from '@ag.ds-next/react/core';
 import { Footer as AgDsFooter, FooterDivider } from '@ag.ds-next/react/footer';
 import { LinkList } from '@ag.ds-next/react/link-list';
 import { Text } from '@ag.ds-next/react/text';
@@ -37,21 +37,24 @@ const footerLinks = [
 export const Footer = () => {
 	const year = useMemo(() => new Date().getFullYear(), []);
 	return (
-		<Box palette="dark">
-			<AgDsFooter background="bodyAlt">
-				<nav aria-label="footer">
-					<LinkList links={footerLinks} horizontal />
-				</nav>
-				<FooterDivider />
-				<Text fontSize="xs" maxWidth={tokens.maxWidth.bodyText}>
-					We acknowledge the traditional owners of country throughout Australia
-					and recognise their continuing connection to land, waters and culture.
-					We pay our respects to their Elders past, present and emerging.
-				</Text>
-				<Text fontSize="xs" maxWidth={tokens.maxWidth.bodyText}>
-					&copy; {year} Department of Agriculture, Fisheries and Forestry
-				</Text>
-			</AgDsFooter>
-		</Box>
+		<CoreProvider>
+			<Box palette="dark">
+				<AgDsFooter background="bodyAlt">
+					<nav aria-label="footer">
+						<LinkList links={footerLinks} horizontal />
+					</nav>
+					<FooterDivider />
+					<Text fontSize="xs" maxWidth={tokens.maxWidth.bodyText}>
+						We acknowledge the traditional owners of country throughout
+						Australia and recognise their continuing connection to land, waters
+						and culture. We pay our respects to their Elders past, present and
+						emerging.
+					</Text>
+					<Text fontSize="xs" maxWidth={tokens.maxWidth.bodyText}>
+						&copy; {year} Department of Agriculture, Fisheries and Forestry
+					</Text>
+				</AgDsFooter>
+			</Box>
+		</CoreProvider>
 	);
 };

--- a/packages/footer/src/Footer.tsx
+++ b/packages/footer/src/Footer.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import { Box } from '@ag.ds-next/react/box';
-import { CoreProvider, tokens } from '@ag.ds-next/react/core';
+import { tokens } from '@ag.ds-next/react/core';
 import { Footer as AgDsFooter, FooterDivider } from '@ag.ds-next/react/footer';
 import { LinkList } from '@ag.ds-next/react/link-list';
 import { Text } from '@ag.ds-next/react/text';
@@ -37,24 +37,21 @@ const footerLinks = [
 export const Footer = () => {
 	const year = useMemo(() => new Date().getFullYear(), []);
 	return (
-		<CoreProvider>
-			<Box palette="dark">
-				<AgDsFooter background="bodyAlt">
-					<nav aria-label="footer">
-						<LinkList links={footerLinks} horizontal />
-					</nav>
-					<FooterDivider />
-					<Text fontSize="xs" maxWidth={tokens.maxWidth.bodyText}>
-						We acknowledge the traditional owners of country throughout
-						Australia and recognise their continuing connection to land, waters
-						and culture. We pay our respects to their Elders past, present and
-						emerging.
-					</Text>
-					<Text fontSize="xs" maxWidth={tokens.maxWidth.bodyText}>
-						&copy; {year} Department of Agriculture, Fisheries and Forestry
-					</Text>
-				</AgDsFooter>
-			</Box>
-		</CoreProvider>
+		<Box palette="dark">
+			<AgDsFooter background="bodyAlt">
+				<nav aria-label="footer">
+					<LinkList links={footerLinks} horizontal />
+				</nav>
+				<FooterDivider />
+				<Text fontSize="xs" maxWidth={tokens.maxWidth.bodyText}>
+					We acknowledge the traditional owners of country throughout Australia
+					and recognise their continuing connection to land, waters and culture.
+					We pay our respects to their Elders past, present and emerging.
+				</Text>
+				<Text fontSize="xs" maxWidth={tokens.maxWidth.bodyText}>
+					&copy; {year} Department of Agriculture, Fisheries and Forestry
+				</Text>
+			</AgDsFooter>
+		</Box>
 	);
 };

--- a/packages/footer/src/__snapshots__/Footer.test.tsx.snap
+++ b/packages/footer/src/__snapshots__/Footer.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Footer renders correctly 1`] = `
 <div>
   <div
-    class="css-9nju69-dark-dark-boxStyles-boxStyles"
+    class="css-yxthkp-dark-dark-boxStyles-boxStyles"
   >
     <footer
       class="css-jig6so-boxStyles-boxStyles-Footer"

--- a/packages/footer/src/index.ts
+++ b/packages/footer/src/index.ts
@@ -1,1 +1,2 @@
+'use client';
 export * from './Footer';

--- a/packages/header/package.json
+++ b/packages/header/package.json
@@ -5,13 +5,13 @@
 	"module": "dist/ag.common-header.esm.js",
 	"license": "MIT",
 	"peerDependencies": {
-		"@ag.ds-next/react": "^1.28.0",
+		"@ag.ds-next/react": "^1.29.0",
 		"@emotion/react": "^11.7.0",
 		"facepaint": "^1.2.1",
 		"react": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
 	},
 	"devDependencies": {
-		"@ag.ds-next/react": "^1.28.0",
+		"@ag.ds-next/react": "^1.29.0",
 		"@emotion/react": "^11.7.0",
 		"facepaint": "^1.2.1",
 		"react": "18.1.0 || 19.0.0"

--- a/packages/header/src/Header.tsx
+++ b/packages/header/src/Header.tsx
@@ -1,4 +1,5 @@
 import { MouseEventHandler } from 'react';
+import { CoreProvider } from '@ag.ds-next/react/core';
 import { Header as AgDsHeader } from '@ag.ds-next/react/header';
 import { AvatarIcon } from '@ag.ds-next/react/icon';
 import { MainNav } from '@ag.ds-next/react/main-nav';
@@ -40,38 +41,40 @@ export const Header = ({
 	focusMode,
 }: HeaderProps) => {
 	return (
-		<Box palette="dark">
-			<AgDsHeader
-				href={authenticated ? '/account' : '/'}
-				heading="Export Service"
-				subline="Supporting Australian agricultural exports"
-				logo={<Logo />}
-				badgeLabel="beta"
-				background="bodyAlt"
-			/>
-			<MainNav
-				id={mainNavId}
-				activePath={activePath}
-				focusMode={focusMode}
-				items={links}
-				secondaryItems={
-					authenticated
-						? [
-								{
-									label: 'My account',
-									href: '/account',
-									endElement: <AvatarIcon />,
-								},
-							]
-						: [
-								{
-									label: 'Sign in',
-									onClick: handleSignIn,
-									endElement: <AvatarIcon />,
-								},
-							]
-				}
-			/>
-		</Box>
+		<CoreProvider>
+			<Box palette="dark">
+				<AgDsHeader
+					href={authenticated ? '/account' : '/'}
+					heading="Export Service"
+					subline="Supporting Australian agricultural exports"
+					logo={<Logo />}
+					badgeLabel="beta"
+					background="bodyAlt"
+				/>
+				<MainNav
+					id={mainNavId}
+					activePath={activePath}
+					focusMode={focusMode}
+					items={links}
+					secondaryItems={
+						authenticated
+							? [
+									{
+										label: 'My account',
+										href: '/account',
+										endElement: <AvatarIcon />,
+									},
+								]
+							: [
+									{
+										label: 'Sign in',
+										onClick: handleSignIn,
+										endElement: <AvatarIcon />,
+									},
+								]
+					}
+				/>
+			</Box>
+		</CoreProvider>
 	);
 };

--- a/packages/header/src/Header.tsx
+++ b/packages/header/src/Header.tsx
@@ -1,14 +1,13 @@
 import { MouseEventHandler } from 'react';
-import { CoreProvider } from '@ag.ds-next/react/core';
 import { Header as AgDsHeader } from '@ag.ds-next/react/header';
 import { AvatarIcon } from '@ag.ds-next/react/icon';
-import { MainNav, MainNavBottomBar } from '@ag.ds-next/react/main-nav';
+import { MainNav } from '@ag.ds-next/react/main-nav';
 import { Logo } from '@ag.ds-next/react/ag-branding';
 import { Box } from '@ag.ds-next/react/box';
 
 export type HeaderProps = {
-	authenticated?: boolean;
 	activePath?: string;
+	authenticated?: boolean;
 	handleSignIn?: MouseEventHandler<HTMLButtonElement>;
 	mainNavId?: string;
 	focusMode?: boolean;
@@ -34,50 +33,45 @@ const links = [
 ];
 
 export const Header = ({
-	authenticated,
 	activePath,
+	authenticated,
 	handleSignIn,
 	mainNavId = 'main-nav',
 	focusMode,
 }: HeaderProps) => {
 	return (
-		<CoreProvider>
-			<Box palette="dark">
-				<AgDsHeader
-					href={authenticated ? '/account' : '/'}
-					heading="Export Service"
-					subline="Supporting Australian agricultural exports"
-					logo={<Logo />}
-					badgeLabel="beta"
-					background="bodyAlt"
-				/>
-				{!focusMode ? (
-					<MainNav
-						id={mainNavId}
-						activePath={activePath}
-						items={links}
-						secondaryItems={
-							authenticated
-								? [
-										{
-											label: 'My account',
-											href: '/account',
-											endElement: <AvatarIcon />,
-										},
-									]
-								: [
-										{
-											label: 'Sign in',
-											onClick: handleSignIn,
-											endElement: <AvatarIcon />,
-										},
-									]
-						}
-					/>
-				) : (
-					<MainNavBottomBar />
-				)}
-			</Box>
-		</CoreProvider>
+		<Box palette="dark">
+			<AgDsHeader
+				href={authenticated ? '/account' : '/'}
+				heading="Export Service"
+				subline="Supporting Australian agricultural exports"
+				logo={<Logo />}
+				badgeLabel="beta"
+				background="bodyAlt"
+			/>
+			<MainNav
+				id={mainNavId}
+				activePath={activePath}
+				focusMode={focusMode}
+				items={links}
+				secondaryItems={
+					authenticated
+						? [
+								{
+									label: 'My account',
+									href: '/account',
+									endElement: <AvatarIcon />,
+								},
+							]
+						: [
+								{
+									label: 'Sign in',
+									onClick: handleSignIn,
+									endElement: <AvatarIcon />,
+								},
+							]
+				}
+			/>
+		</Box>
 	);
 };

--- a/packages/header/src/__snapshots__/Header.test.tsx.snap
+++ b/packages/header/src/__snapshots__/Header.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Header authenticated renders correctly 1`] = `
 <div>
   <div
-    class="css-9nju69-dark-dark-boxStyles-boxStyles"
+    class="css-yxthkp-dark-dark-boxStyles-boxStyles"
   >
     <header
       class="css-1yas2mc-boxStyles-boxStyles"
@@ -226,7 +226,7 @@ exports[`Header authenticated renders correctly 1`] = `
 exports[`Header unauthenticated renders correctly 1`] = `
 <div>
   <div
-    class="css-9nju69-dark-dark-boxStyles-boxStyles"
+    class="css-yxthkp-dark-dark-boxStyles-boxStyles"
   >
     <header
       class="css-1yas2mc-boxStyles-boxStyles"

--- a/packages/header/src/index.ts
+++ b/packages/header/src/index.ts
@@ -1,1 +1,2 @@
+'use client';
 export * from './Header';

--- a/packages/help-callout/package.json
+++ b/packages/help-callout/package.json
@@ -5,13 +5,13 @@
 	"module": "dist/ag.common-help-callout.esm.js",
 	"license": "MIT",
 	"peerDependencies": {
-		"@ag.ds-next/react": "^1.28.0",
+		"@ag.ds-next/react": "^1.29.0",
 		"@emotion/react": "^11.7.0",
 		"facepaint": "^1.2.1",
 		"react": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
 	},
 	"devDependencies": {
-		"@ag.ds-next/react": "^1.28.0",
+		"@ag.ds-next/react": "^1.29.0",
 		"@emotion/react": "^11.7.0",
 		"facepaint": "^1.2.1",
 		"react": "18.1.0 || 19.0.0"

--- a/packages/help-callout/src/HelpCallout.tsx
+++ b/packages/help-callout/src/HelpCallout.tsx
@@ -1,3 +1,4 @@
+import { CoreProvider } from '@ag.ds-next/react/core';
 import { Callout } from '@ag.ds-next/react/callout';
 import { Text } from '@ag.ds-next/react/text';
 import { TextLink, TextLinkExternal } from '@ag.ds-next/react/text-link';
@@ -12,28 +13,30 @@ export const HelpCallout = (props: HelpCalloutProps) => {
 	const LinkComponent = props?.internal === true ? TextLink : TextLinkExternal;
 
 	return (
-		<Callout
-			title={
-				props?.hideHelpArticles === true ? 'Need more help?' : 'Need help?'
-			}
-		>
-			{props?.hideHelpArticles === true ? null : (
+		<CoreProvider>
+			<Callout
+				title={
+					props?.hideHelpArticles === true ? 'Need more help?' : 'Need help?'
+				}
+			>
+				{props?.hideHelpArticles === true ? null : (
+					<Text>
+						Search our{' '}
+						<LinkComponent href={props.helpHref ?? '/help'}>Help</LinkComponent>{' '}
+						pages
+					</Text>
+				)}
 				<Text>
-					Search our{' '}
-					<LinkComponent href={props.helpHref ?? '/help'}>Help</LinkComponent>{' '}
-					pages
+					Email{' '}
+					<TextLink href="mailto:exportservice@aff.gov.au">
+						exportservice@aff.gov.au
+					</TextLink>
 				</Text>
-			)}
-			<Text>
-				Email{' '}
-				<TextLink href="mailto:exportservice@aff.gov.au">
-					exportservice@aff.gov.au
-				</TextLink>
-			</Text>
-			<Text>
-				Call <TextLink href="tel:1800571125">1800&nbsp;571&nbsp;125</TextLink>,
-				Monday to Friday, 9 am to 5 pm AEST
-			</Text>
-		</Callout>
+				<Text>
+					Call <TextLink href="tel:1800571125">1800&nbsp;571&nbsp;125</TextLink>
+					, Monday to Friday, 9 am to 5 pm AEST
+				</Text>
+			</Callout>
+		</CoreProvider>
 	);
 };

--- a/packages/help-callout/src/HelpCallout.tsx
+++ b/packages/help-callout/src/HelpCallout.tsx
@@ -1,5 +1,4 @@
 import { Callout } from '@ag.ds-next/react/callout';
-import { CoreProvider } from '@ag.ds-next/react/core';
 import { Text } from '@ag.ds-next/react/text';
 import { TextLink, TextLinkExternal } from '@ag.ds-next/react/text-link';
 
@@ -13,30 +12,28 @@ export const HelpCallout = (props: HelpCalloutProps) => {
 	const LinkComponent = props?.internal === true ? TextLink : TextLinkExternal;
 
 	return (
-		<CoreProvider>
-			<Callout
-				title={
-					props?.hideHelpArticles === true ? 'Need more help?' : 'Need help?'
-				}
-			>
-				{props?.hideHelpArticles === true ? null : (
-					<Text>
-						Search our{' '}
-						<LinkComponent href={props.helpHref ?? '/help'}>Help</LinkComponent>{' '}
-						pages
-					</Text>
-				)}
+		<Callout
+			title={
+				props?.hideHelpArticles === true ? 'Need more help?' : 'Need help?'
+			}
+		>
+			{props?.hideHelpArticles === true ? null : (
 				<Text>
-					Email{' '}
-					<TextLink href="mailto:exportservice@aff.gov.au">
-						exportservice@aff.gov.au
-					</TextLink>
+					Search our{' '}
+					<LinkComponent href={props.helpHref ?? '/help'}>Help</LinkComponent>{' '}
+					pages
 				</Text>
-				<Text>
-					Call <TextLink href="tel:1800571125">1800&nbsp;571&nbsp;125</TextLink>
-					, Monday to Friday, 9 am to 5 pm AEST
-				</Text>
-			</Callout>
-		</CoreProvider>
+			)}
+			<Text>
+				Email{' '}
+				<TextLink href="mailto:exportservice@aff.gov.au">
+					exportservice@aff.gov.au
+				</TextLink>
+			</Text>
+			<Text>
+				Call <TextLink href="tel:1800571125">1800&nbsp;571&nbsp;125</TextLink>,
+				Monday to Friday, 9 am to 5 pm AEST
+			</Text>
+		</Callout>
 	);
 };

--- a/packages/help-callout/src/HelpCallout.tsx
+++ b/packages/help-callout/src/HelpCallout.tsx
@@ -1,5 +1,5 @@
-import { CoreProvider } from '@ag.ds-next/react/core';
 import { Callout } from '@ag.ds-next/react/callout';
+import { CoreProvider } from '@ag.ds-next/react/core';
 import { Text } from '@ag.ds-next/react/text';
 import { TextLink, TextLinkExternal } from '@ag.ds-next/react/text-link';
 

--- a/packages/help-callout/src/index.ts
+++ b/packages/help-callout/src/index.ts
@@ -1,1 +1,2 @@
+'use client';
 export * from './HelpCallout';

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,13 +16,13 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@ag.common/analytics@workspace:packages/analytics"
   dependencies:
-    "@ag.ds-next/react": "npm:^1.28.0"
+    "@ag.ds-next/react": "npm:^1.29.0"
     "@emotion/react": "npm:^11.7.0"
     "@types/gtag.js": "npm:^0.0.12"
     facepaint: "npm:^1.2.1"
     react: "npm:18.1.0 || 19.0.0"
   peerDependencies:
-    "@ag.ds-next/react": ^1.28.0
+    "@ag.ds-next/react": ^1.29.0
     "@emotion/react": ^11.7.0
     "@types/gtag.js": ^0.0.12
     facepaint: ^1.2.1
@@ -34,12 +34,12 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@ag.common/app-layout@workspace:packages/app-layout"
   dependencies:
-    "@ag.ds-next/react": "npm:^1.28.0"
+    "@ag.ds-next/react": "npm:^1.29.0"
     "@emotion/react": "npm:^11.7.0"
     facepaint: "npm:^1.2.1"
     react: "npm:18.1.0 || 19.0.0"
   peerDependencies:
-    "@ag.ds-next/react": ^1.28.0
+    "@ag.ds-next/react": ^1.29.0
     "@emotion/react": ^11.7.0
     facepaint: ^1.2.1
     react: ^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -50,12 +50,12 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@ag.common/digital-identity@workspace:packages/digital-identity"
   dependencies:
-    "@ag.ds-next/react": "npm:^1.28.0"
+    "@ag.ds-next/react": "npm:^1.29.0"
     "@emotion/react": "npm:^11.7.0"
     facepaint: "npm:^1.2.1"
     react: "npm:18.1.0 || 19.0.0"
   peerDependencies:
-    "@ag.ds-next/react": ^1.28.0
+    "@ag.ds-next/react": ^1.29.0
     "@emotion/react": ^11.7.0
     facepaint: ^1.2.1
     react: ^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -66,12 +66,12 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@ag.common/footer@workspace:packages/footer"
   dependencies:
-    "@ag.ds-next/react": "npm:^1.28.0"
+    "@ag.ds-next/react": "npm:^1.29.0"
     "@emotion/react": "npm:^11.7.0"
     facepaint: "npm:^1.2.1"
     react: "npm:18.1.0 || 19.0.0"
   peerDependencies:
-    "@ag.ds-next/react": ^1.28.0
+    "@ag.ds-next/react": ^1.29.0
     "@emotion/react": ^11.7.0
     facepaint: ^1.2.1
     react: ^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -82,12 +82,12 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@ag.common/header@workspace:packages/header"
   dependencies:
-    "@ag.ds-next/react": "npm:^1.28.0"
+    "@ag.ds-next/react": "npm:^1.29.0"
     "@emotion/react": "npm:^11.7.0"
     facepaint: "npm:^1.2.1"
     react: "npm:18.1.0 || 19.0.0"
   peerDependencies:
-    "@ag.ds-next/react": ^1.28.0
+    "@ag.ds-next/react": ^1.29.0
     "@emotion/react": ^11.7.0
     facepaint: ^1.2.1
     react: ^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -98,23 +98,23 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@ag.common/help-callout@workspace:packages/help-callout"
   dependencies:
-    "@ag.ds-next/react": "npm:^1.28.0"
+    "@ag.ds-next/react": "npm:^1.29.0"
     "@emotion/react": "npm:^11.7.0"
     facepaint: "npm:^1.2.1"
     react: "npm:18.1.0 || 19.0.0"
   peerDependencies:
-    "@ag.ds-next/react": ^1.28.0
+    "@ag.ds-next/react": ^1.29.0
     "@emotion/react": ^11.7.0
     facepaint: ^1.2.1
     react: ^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
   languageName: unknown
   linkType: soft
 
-"@ag.ds-next/react@npm:^1.28.0":
-  version: 1.28.0
-  resolution: "@ag.ds-next/react@npm:1.28.0"
+"@ag.ds-next/react@npm:^1.29.0":
+  version: 1.29.0
+  resolution: "@ag.ds-next/react@npm:1.29.0"
   dependencies:
-    "@babel/runtime": "npm:^7.4.5"
+    "@babel/runtime": "npm:^7.27.1"
     "@floating-ui/react-dom": "npm:^2.0.8"
     "@types/facepaint": "npm:^1.2.5"
     date-fns: "npm:^2.28.0"
@@ -129,7 +129,7 @@ __metadata:
     "@emotion/react": ^11.7.0
     react: ^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
     react-dom: ^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-  checksum: 10c0/3caa6c9164ceaca4d626ed3eaa5439f3a4d02984c810c107d43c3766b48f77c78c47ecdcafb417f32bf5fd96fd8d03f5c65323e27fc343ddcd1a238fc754ce7d
+  checksum: 10c0/f537f6733decc7aea55ff4d70bf5070657bcfb1d69340ef5014a1991a485edd7d4afa1f2c5a4943502b6d1b724198ecd4c02ca032194fa0996ca70d156a1de24
   languageName: node
   linkType: hard
 
@@ -1470,10 +1470,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.12.13, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.17.8, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.21.0, @babel/runtime@npm:^7.24.5, @babel/runtime@npm:^7.4.5, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.7.7, @babel/runtime@npm:^7.9.2":
+"@babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.12.13, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.17.8, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.21.0, @babel/runtime@npm:^7.24.5, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.7.7, @babel/runtime@npm:^7.9.2":
   version: 7.27.1
   resolution: "@babel/runtime@npm:7.27.1"
   checksum: 10c0/530a7332f86ac5a7442250456823a930906911d895c0b743bf1852efc88a20a016ed4cd26d442d0ca40ae6d5448111e02a08dd638a4f1064b47d080e2875dc05
+  languageName: node
+  linkType: hard
+
+"@babel/runtime@npm:^7.27.1":
+  version: 7.27.4
+  resolution: "@babel/runtime@npm:7.27.4"
+  checksum: 10c0/ca99e964179c31615e1352e058cc9024df7111c829631c90eec84caba6703cc32acc81503771847c306b3c70b815609fe82dde8682936debe295b0b283b2dc6e
   languageName: node
   linkType: hard
 
@@ -4335,7 +4342,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "ag-common@workspace:."
   dependencies:
-    "@ag.ds-next/react": "npm:^1.28.0"
+    "@ag.ds-next/react": "npm:^1.29.0"
     "@babel/core": "npm:^7.24.0"
     "@babel/plugin-transform-runtime": "npm:^7.24.0"
     "@babel/preset-env": "npm:^7.24.0"


### PR DESCRIPTION
## Describe your changes

Trying to use ag.common components in a Next.js App Router app was a bit painful, as relevant components weren't set as client components with `'use client'`.

I also updated any use of deprecated components.

## Checklist

- [x] Read and check your code before tagging someone for review.
- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [ ] Add necessary tests
- [x] Run `yarn changeset` to create a changeset file
- [ ] Write documentation (README.md)
- [ ] Create stories for Storybook
