### PR TITLE
fix(app-layout): retain business header and Help/Sign-out links when custom sidebarItems is supplied

### DIFF
--- a/.changeset/fix-sidebar-items-parity.md
+++ b/.changeset/fix-sidebar-items-parity.md
@@ -1,0 +1,5 @@
+---
+"@ag.common/app-layout": patch
+---
+
+app-layout: retain business header and Help/Sign-out links in the sidebar when a custom `sidebarItems` prop is supplied

--- a/packages/app-layout/src/AppLayout.tsx
+++ b/packages/app-layout/src/AppLayout.tsx
@@ -22,7 +22,7 @@ import {
 	findBestMatch,
 	getFooterLinks,
 	getAppLinks,
-	getSidebarLinks,
+	getBottomSidebarLinks,
 } from './utils';
 import {
 	BusinessDropdown,
@@ -136,12 +136,17 @@ export function AppLayout<B extends Business>({
 	const routes = createRoutes(domain);
 	const appLinks = useMemo(() => getAppLinks({ features, routes }), [features]);
 	const footerLinks = getFooterLinks(routes);
+	const businessSidebarLinks = useMemo(
+		() => getBusinessSidebarLinks({ details: businessDetails, routes }),
+		[businessDetails, routes]
+	);
+	const bottomSidebarLinks = useMemo(
+		() => getBottomSidebarLinks({ onSignOutClick, routes }),
+		[onSignOutClick, routes]
+	);
 	const sidebarLinks = useMemo(
-		() => [
-			...getBusinessSidebarLinks({ details: businessDetails, routes }),
-			...getSidebarLinks({ onSignOutClick, features, routes }),
-		],
-		[onSignOutClick, businessDetails, features]
+		() => [...businessSidebarLinks, appLinks, ...bottomSidebarLinks],
+		[businessSidebarLinks, appLinks, bottomSidebarLinks]
 	);
 
 	// we always build these in order to respect hook conditional rules
@@ -193,7 +198,12 @@ export function AppLayout<B extends Business>({
 						<CoreProvider {...parentCoreContext}>
 							<AgDsAppLayoutSidebar
 								activePath={activePath_} // use unmodified path here so that custom sidenav items don't need to be expanded into fully qualified urls
-								items={sidebarItems}
+								// wrap custom items with the same business header + Help/Sign out sections as the default sidebar, so callers only need to supply the app-specific nav
+								items={[
+									...businessSidebarLinks,
+									...sidebarItems,
+									...bottomSidebarLinks,
+								]}
 								subLevelVisible={sidebarSubLevelVisible}
 								background="body"
 							/>

--- a/packages/app-layout/src/utils.tsx
+++ b/packages/app-layout/src/utils.tsx
@@ -117,16 +117,15 @@ export const getFooterLinks = (routes: AppRoutes) => [
 	{ href: routes.privacy, label: 'Privacy' },
 ];
 
-export const getSidebarLinks = ({
+// Help + Sign out — kept separate from getAppLinks so callers supplying custom
+// sidebarItems can still be wrapped with this section for parity with the default sidebar.
+export const getBottomSidebarLinks = ({
 	onSignOutClick,
-	features,
 	routes,
 }: {
 	onSignOutClick: () => void;
-	features?: Features;
 	routes: AppRoutes;
 }) => [
-	getAppLinks({ features, routes }),
 	[
 		{
 			label: (


### PR DESCRIPTION
## Problem

When a caller supplies a custom sidebarItems prop to AppLayout, the entire default sidebar composition (business/back-to-export header, app nav, Help + Sign out) is replaced with just the caller's items - dropping the business context header and the Help/Sign-out links.

## Fix

Split getSidebarLinks into getBottomSidebarLinks (Help + Sign out only) so it can be composed independently of the app nav links. AppLayout now wraps any caller-supplied sidebarItems with the same business header and Help/Sign-out sections used by the default sidebar, so custom navigation retains parity with the default experience instead of losing surrounding chrome.

The default (no sidebarItems) rendering path is unchanged - same composition and order as before (business links + app links + Help/Sign out), just computed via the renamed/split helper functions.

## Changes
- packages/app-layout/src/utils.tsx: replaced getSidebarLinks with getBottomSidebarLinks (Help + Sign out only)
- packages/app-layout/src/AppLayout.tsx: compute usinessSidebarLinks and ottomSidebarLinks separately; wrap custom sidebarItems with both
- Added a patch changeset

## Testing
- Verified no remaining references to the removed getSidebarLinks export
- No TypeScript errors reported for either modified file